### PR TITLE
Fixed compile warnings that prevented build on R17

### DIFF
--- a/include/rafter_consensus_fsm.hrl
+++ b/include/rafter_consensus_fsm.hrl
@@ -19,12 +19,12 @@
     timer :: reference(),
 
     %% leader state: contains nextIndex for each peer
-    followers = dict:new() :: dict(),
+    followers = dict:new() :: dict:new(),
 
     %% Dict keyed by peer id.
     %% contains true as val when candidate
     %% contains match_indexes as val when leader
-    responses = dict:new() :: dict(),
+    responses = dict:new() :: dict:new(),
 
     %% Logical clock to allow read linearizability
     %% Reset to 0 on leader election.
@@ -32,7 +32,7 @@
 
     %% Keep track of the highest send_clock received from each peer
     %% Reset on leader election
-    send_clock_responses = dict:new() :: dict(),
+    send_clock_responses = dict:new() :: dict:new(),
 
     %% Outstanding Client Write Requests
     client_reqs = [] :: [#client_req{}],

--- a/src/rafter_config.erl
+++ b/src/rafter_config.erl
@@ -10,7 +10,7 @@
 %% API
 %%====================================================================
 
--spec quorum_max(peer(), #config{} | [], dict()) -> non_neg_integer().
+-spec quorum_max(peer(), #config{} | [], dict:new()) -> non_neg_integer().
 quorum_max(_Me, #config{state=blank}, _) ->
     0;
 quorum_max(Me, #config{state=stable, oldservers=OldServers}, Responses) ->
@@ -34,7 +34,7 @@ quorum_max(Me, Servers, Responses) ->
     Values = sorted_values(Me, Servers, Responses),
     lists:nth(length(Values) div 2 + 1, Values).
 
--spec quorum(peer(), #config{} | list(), dict()) -> boolean().
+-spec quorum(peer(), #config{} | list(), dict:new()) -> boolean().
 quorum(_Me, #config{state=blank}, _Responses) ->
     false;
 quorum(Me, #config{state=stable, oldservers=OldServers}, Responses) ->
@@ -112,7 +112,7 @@ allow_config(_Config, _NewServers) ->
 %% Internal Functions
 %%====================================================================
 
--spec sorted_values(peer(), [peer()], dict()) -> [non_neg_integer()].
+-spec sorted_values(peer(), [peer()], dict:new()) -> [non_neg_integer()].
 sorted_values(Me, Servers, Responses) ->
     Vals = lists:sort(lists:map(fun(S) -> value(S, Responses) end, Servers)),
     case lists:member(Me, Servers) of
@@ -125,7 +125,7 @@ sorted_values(Me, Servers, Responses) ->
             Vals
     end.
 
--spec value(peer(), dict()) -> non_neg_integer().
+-spec value(peer(), dict:new()) -> non_neg_integer().
 value(Peer, Responses) ->
     case dict:find(Peer, Responses) of
         {ok, Value} ->

--- a/src/rafter_consensus_fsm.erl
+++ b/src/rafter_consensus_fsm.erl
@@ -472,7 +472,7 @@ no_leader_error(Me, Config) ->
             election_in_progress
     end.
 
--spec reconfig(term(), dict(), #config{}, list(), #state{}) -> {dict(), #config{}}.
+-spec reconfig(term(), dict:new(), #config{}, list(), #state{}) -> {dict:new(), #config{}}.
 reconfig(Me, OldFollowers, Config0, NewServers, State) ->
     Config = rafter_config:reconfig(Config0, NewServers),
     NewFollowers = rafter_config:followers(Me, Config),
@@ -484,13 +484,13 @@ reconfig(Me, OldFollowers, Config0, NewServers, State) ->
     Followers = remove_followers(RemovedServers, Followers0),
     {Followers, Config}.
 
--spec add_followers(list(), dict(), #state{}) -> dict().
+-spec add_followers(list(), dict:new(), #state{}) -> dict:new().
 add_followers(NewServers, Followers, #state{me=Me}) ->
     NextIndex = rafter_log:get_last_index(Me) + 1,
     NewFollowers = [{S, NextIndex} || S <- NewServers],
     dict:from_list(NewFollowers ++ dict:to_list(Followers)).
 
--spec remove_followers(list(), dict()) -> dict().
+-spec remove_followers(list(), dict:new()) -> dict:new().
 remove_followers(Servers, Followers0) ->
     lists:foldl(fun(S, Followers) ->
                     dict:erase(S, Followers)


### PR DESCRIPTION
Fixed 'type dict/0 is deprecated and will be removed in OTP 18.0' warnings that prevented build on R17.

To reproduce problem on a box running R17...

$ git clone git@github.com:andrewjstone/rafter.git
$ cd rafter
$ make deps
$ make
...
==> rafter (compile)
Compiled src/rafter_backend.erl
Compiled src/rafter_app.erl
compile: warnings being treated as errors
include/rafter_consensus_fsm.hrl:22: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
include/rafter_consensus_fsm.hrl:27: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
include/rafter_consensus_fsm.hrl:35: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
make: **\* [rafter] Error 1

...fixed these...

$ make
...
==> rafter (compile)
Compiled src/rafter_backend_echo.erl
Compiled src/rafter.erl
Compiled src/rafter_backend_ets.erl
Compiled src/rafter_consensus_sup.erl
compile: warnings being treated as errors
src/rafter_config.erl:13: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
src/rafter_config.erl:37: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
src/rafter_config.erl:115: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
src/rafter_config.erl:128: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
make: **\* [rafter] Error 1

...fixed these...

$ make
...
==> rafter (compile)
Compiled src/rafter_config.erl
Compiled src/rafter_log.erl
compile: warnings being treated as errors
src/rafter_consensus_fsm.erl:475: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
src/rafter_consensus_fsm.erl:475: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
src/rafter_consensus_fsm.erl:487: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
src/rafter_consensus_fsm.erl:487: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
src/rafter_consensus_fsm.erl:493: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
src/rafter_consensus_fsm.erl:493: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
make: **\* [rafter] Error 1

$ make
... 
All good. :)
