### PR TITLE
Added druuid to app.src

### DIFF
--- a/src/rafter.app.src
+++ b/src/rafter.app.src
@@ -4,6 +4,7 @@
   {vsn, "1"},
   {registered, []},
   {applications, [
+                  druuid,
                   lager,
                   kernel,
                   stdlib


### PR DESCRIPTION
Releases currently won't include druuid, this pull request ensures that they will.