### PR TITLE
Fix overwrite log bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 deps
 log
+logs
 ebin
 .eunit
 *.beam
 *.swp
 erl_crash.dump
-

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test deps
+.PHONY: test ct-test deps
 
 rafter:
 	./rebar compile
@@ -7,17 +7,20 @@ deps:
 test:
 	./rebar eunit skip_deps=true
 
+ct-test:
+	./rebar ct skip_deps=true
+
 APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \
 	xmerl webtool eunit syntax_tools compiler
 PLT = $(HOME)/.rafter_dialyzer_plt
 
-check_plt: 
+check_plt:
 	dialyzer --check_plt --plt $(PLT) --apps $(APPS)
 
-build_plt: 
+build_plt:
 	dialyzer --build_plt --output_plt $(PLT) --apps $(APPS)
 
-dialyzer: 
+dialyzer:
 	@echo
 	@echo Use "'make check_plt'" to check PLT prior to using this target.
 	@echo Use "'make build_plt'" to build PLT prior to using this target.

--- a/src/rafter_log.erl
+++ b/src/rafter_log.erl
@@ -244,9 +244,9 @@ handle_call({check_and_append, Entries, Index}, _From, #state{logfile=File,
 handle_call({get_entry, Index}, _From, #state{logfile=File,
                                               hints=Hints}=State0) ->
     Loc = closest_forward_offset(Hints, Index),
-    {Res, NewState} = 
+    {Res, NewState} =
     case find_entry(File, Loc, Index) of
-        {not_found, Count} -> 
+        {not_found, Count} ->
             State = update_counters(Count, 0, State0),
             {not_found, State};
         {Entry, NextLoc, Count} ->
@@ -266,9 +266,9 @@ update_counters(Distance, Prunes, #state{hint_prunes=Prunes0,
 -spec closest_forward_offset(ets:tid(), index()) -> offset().
 closest_forward_offset(Hints, Index) ->
     case ets:prev(Hints, Index) of
-        '$end_of_table' -> 
+        '$end_of_table' ->
             ?FILE_HEADER_SIZE;
-        Key -> 
+        Key ->
             [{Key, Loc0}] = ets:lookup(Hints, Key),
             Loc0
     end.
@@ -289,7 +289,7 @@ add_hint(Hints, Index, Loc) ->
 %% Delete every 10th hint
 delete_hints(Hints) ->
     L = ets:tab2list(Hints),
-    {_, ToDelete} =  
+    {_, ToDelete} =
     lists:foldl(fun({Index, _}, {Count, Deleted}) when Count rem 10 =:= 0 ->
                        {Count+1, [Index | Deleted]};
                    ({_, _}, {Count, Deleted}) ->
@@ -331,7 +331,7 @@ maybe_append(Index, Loc, [#rafter_entry{term=Term}=Entry | Entries],
                     maybe_append(Index+1, NewLocation, Entries, State);
                 #rafter_entry{index=Index, term=_} ->
                     ok = truncate(File, Loc),
-                    State1 = State#state{write_location=Loc},
+                    State1 = State#state{write_location=Loc, index=Index-1},
                     State2 = write_entry(Entry, State1),
                     maybe_append(Index + 1, eof, Entries, State2)
             end;

--- a/test/rafter_SUITE.erl
+++ b/test/rafter_SUITE.erl
@@ -1,0 +1,56 @@
+-module(rafter_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("rafter/include/rafter_opts.hrl").
+-include_lib("rafter/include/rafter.hrl").
+
+-export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
+-export([t_overwrite_bug/1]).
+
+suite() ->
+    [{timetrap,{seconds,30}}].
+
+all() ->
+    [
+     t_overwrite_bug
+    ].
+
+init_per_suite(Config) ->
+    {ok, Dir} = file:get_cwd(),
+    filelib:ensure_dir(filename:join([Dir, "logs", "file"])),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+t_overwrite_bug(_Config) ->
+    Peer = 'dev1@127.0.0.1dev2@127.0.0.1dev4@127.0.0.1',
+    Opts = #rafter_opts{state_machine=rafter_backend_ets,
+                        logdir="./logs"},
+    {ok, _Pid} = rafter_log:start_link(Peer, Opts),
+
+    #config{state=blank} = rafter_log:get_config(Peer),
+    {ok, not_found}      = rafter_log:get_last_entry(Peer),
+    0                    = rafter_log:get_last_index(Peer),
+
+    Config = #config{state=stable,
+                     oldservers=[{'dev1@127.0.0.1dev2@127.0.0.1dev4@127.0.0.1',
+                                  'dev1@127.0.0.1'},
+                                 {'dev1@127.0.0.1dev2@127.0.0.1dev4@127.0.0.1',
+                                  'dev2@127.0.0.1'},
+                                 {'dev1@127.0.0.1dev2@127.0.0.1dev4@127.0.0.1',
+                                  'dev4@127.0.0.1'}]},
+
+    Entry0 = #rafter_entry{type=config,term=1,index=undefined,cmd=Config},
+    {ok, 1} = rafter_log:append(Peer, [Entry0]),
+
+    Entry1 = Entry0#rafter_entry{index=1},
+    {ok, Entry1} = rafter_log:get_entry(Peer, 1),
+
+    % same index, different term
+    Entry2 = Entry1#rafter_entry{term=2},
+    {ok, 1} = rafter_log:check_and_append(Peer, [Entry2], 1),
+    Config = rafter_log:get_config(Peer),
+    {ok, Entry2} = rafter_log:get_entry(Peer, 1),
+
+    ok.

--- a/test/rafter_SUITE.erl
+++ b/test/rafter_SUITE.erl
@@ -1,8 +1,8 @@
 -module(rafter_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
--include_lib("rafter/include/rafter_opts.hrl").
--include_lib("rafter/include/rafter.hrl").
+-include("rafter_opts.hrl").
+-include("rafter.hrl").
 
 -export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
 -export([t_overwrite_bug/1]).


### PR DESCRIPTION
Hey @andrewjstone,
so I discovered that when a leader want to overwrite some entries in followers log it sets a wrong index.

An example:
* follower has an entry with `term=1` and `index=1` and leader sends an entry with `term=2` and `index=1`;
* now: follower's entry is overwritten with an entry with `term=2` and `index=2`;
* should be: follower's entry is overwritten with an entry with `term=2` and `index=1`.

I attached a test with this case.

Sorry, I do not have a eqc license, so I couldn't run eqc tests.

And fyi, I am also working on proper statem for rafter_log, as I want to use rafter on production (really badly). Will ping you when it is ready.