### PR TITLE
No longer an artificial delay between getting votes, and becoming a leader, for an initial configuration

### DIFF
--- a/src/rafter_consensus_fsm.erl
+++ b/src/rafter_consensus_fsm.erl
@@ -823,14 +823,13 @@ become_candidate(#state{term=CurrentTerm, me=Me}=State0) ->
     _ = request_votes(State3),
     State3.
 
-become_leader(#state{me=Me, term=Term, config=Config, init_config=InitConfig, timer=Timer}=State) ->
+become_leader(#state{me=Me, term=Term, config=Config, init_config=InitConfig}=State) ->
     NewState0 = State#state{leader=Me,
                            responses=dict:new(),
                            followers=initialize_followers(State),
                            send_clock = 0,
                            send_clock_responses = dict:new(),
-                           read_reqs = orddict:new(),
-                           timer = Timer},
+                           read_reqs = orddict:new()},
 
     case InitConfig of
         complete ->

--- a/src/rafter_consensus_fsm.erl
+++ b/src/rafter_consensus_fsm.erl
@@ -339,24 +339,6 @@ candidate({read_op, _}, _, #state{leader=undefined}=State) ->
 candidate({op, _Command}, _From, #state{leader=undefined}=State) ->
     {reply, {error, election_in_progress}, candidate, State}.
 
-leader(timeout, #state{term=Term,
-                       init_config=no_client,
-                       config=C}=S) ->
-    Entry = #rafter_entry{type=config, term=Term, cmd=C},
-    State0 = append(Entry, S),
-    State = reset_timer(heartbeat_timeout(), State0),
-    NewState = State#state{init_config=complete},
-    {next_state, leader, NewState};
-
-%% We have just been elected leader because of an initial configuration.
-%% Append the initial config and set init_config=complete.
-leader(timeout, #state{term=Term, init_config=[Id, From], config=C}=S) ->
-    State0 = reset_timer(heartbeat_timeout(), S),
-    Entry = #rafter_entry{type=config, term=Term, cmd=C},
-    State = append(Id, From, Entry, State0, leader),
-    NewState = State#state{init_config=complete},
-    {next_state, leader, NewState};
-
 leader(timeout, State0) ->
     State = reset_timer(heartbeat_timeout(), State0),
     NewState = send_append_entries(State),
@@ -841,24 +823,38 @@ become_candidate(#state{term=CurrentTerm, me=Me}=State0) ->
     _ = request_votes(State3),
     State3.
 
-become_leader(#state{me=Me, term=Term, init_config=InitConfig}=State) ->
-    NewState = State#state{leader=Me,
+become_leader(#state{me=Me, term=Term, config=Config, init_config=InitConfig, timer=Timer}=State) ->
+    NewState0 = State#state{leader=Me,
                            responses=dict:new(),
                            followers=initialize_followers(State),
                            send_clock = 0,
                            send_clock_responses = dict:new(),
-                           read_reqs = orddict:new()},
+                           read_reqs = orddict:new(),
+                           timer = Timer},
 
     case InitConfig of
         complete ->
             %% Commit a noop entry to the log so we can move the commit index
             Entry = #rafter_entry{type=noop, term=Term, cmd=noop},
-            append(Entry, NewState);
-        _ ->
-            %% First entry must always be a config entry
-            NewState
+            append(Entry, NewState0);
+        undefined ->
+            %% Same as above, but we received our config from another node
+            Entry = #rafter_entry{type=noop, term=Term, cmd=noop},
+            NewState1 = append(Entry, NewState0),
+            NewState1#state{init_config=complete};
+        [Id, From] ->
+            %% Initial config, append it, and set init_config=complete
+            Entry = #rafter_entry{type=config, term=Term, cmd=Config},
+            NewState1 = append(Id, From, Entry, NewState0, leader),
+            NewState2 = reset_timer(heartbeat_timeout(), NewState1),
+            NewState2#state{init_config=complete};
+        no_client ->
+            %% Same as above, but no-one to tell
+            Entry = #rafter_entry{type=config, term=Term, cmd=Config},
+            NewState1 = append(Entry, NewState0),
+            NewState2 = reset_timer(heartbeat_timeout(), NewState1),
+            NewState2#state{init_config=complete}
     end.
-
 
 initialize_followers(#state{me=Me, config=Config}) ->
     Peers = rafter_config:followers(Me, Config),


### PR DESCRIPTION
We discovered in testing, that if you've got a brand new cluster, and you call `set_config(...)` on the node you wish to be the leader of the new cluster, that it doesn't become the leader as soon as it has gathered enough votes. It will end up waiting whatever the remainder of the `election_timeout()`  is.

This is because `become_leader(...)` when `init_config` is not `complete` doesn't really do anything, instead it waits for whatever timer is currently set-up to trigger a `timeout` in the leader state.

I think the best thing to do, and what I've implemented, is to have `become_leader(...)` do the work that was originally done in special cases of `leader(timeout, ...)`.

There is one thing I'm unsure about, which is the behaviour when `init_config` is `undefined`, which can happen if a node comes up with no log, and then is joined to the cluster by another node. If the leader of the cluster at that point becomes unavailable, the node with `init_config` of `undefined` can become a candidate, and then become the leader. In this case rafter is not adding a no-op entry to the log, which I'm pretty sure isn't the right thing to do - so I've made that case basically the same as when `init_config` is `complete`. Hopefully that's the right thing to do.